### PR TITLE
Support channel passwords, bugfix for NICK events

### DIFF
--- a/bot/loggy.py
+++ b/bot/loggy.py
@@ -169,7 +169,10 @@ class Loggy(Bot):
    def lognick(self, origin, command, channel, args, text): 
       old = origin.nick
       new = text
-      self.log('*** %s is now known as %s' % (old, new), channel)
+
+      for channel in self.channels:
+         if old in self.userlist[channel]:
+            self.log('*** %s is now known as %s' % (old, new), channel)
 
    def logmodechange(self, origin, command, channel, args, text):
       if origin.nick == self.nick: return


### PR DESCRIPTION
NICK events do not have a channel associated with them. They require
mapping a la logquit, simple fix.

This also introduces the ability to specify channel passwords on the
command line in the form:

  irc://server/channel1+password1,channel2+password2,...
